### PR TITLE
Added reset of acebook-test database before each cypress test 

### DIFF
--- a/cypress/integration/profile_view_profile_spec.js
+++ b/cypress/integration/profile_view_profile_spec.js
@@ -24,7 +24,7 @@ describe("View Profile", () => {
   it("gives a 404 page not found if no user is found", () => {
 
     cy.request({
-      url:'127.0.0.1:3000//users/6230aed25edef17cd0a07d40',
+      url:'127.0.0.1:3030//users/6230aed25edef17cd0a07d40',
       failOnStatusCode: false
     }).should((response) => {
       expect(response.status).to.eq(404)
@@ -36,7 +36,7 @@ describe("View Profile", () => {
   it("shows Error if something goes wrong or nonsense passed in URL", () => {
 
     cy.request({
-      url:'127.0.0.1:3000//users/nonsenseblah',
+      url:'127.0.0.1:3030//users/nonsenseblah',
       failOnStatusCode: false
     }).should((response) => {
       expect(response.status).to.eq(404)

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -12,7 +12,57 @@
 // the project's config changing)
 
 
-module.exports = function() {
-  // `on` is used to hook into various events Cypress emits
-  // `config` is the resolved Cypress config
+// module.exports = function() {
+//   // `on` is used to hook into various events Cypress emits
+//   // `config` is the resolved Cypress config
+// }
+var mongoose = require('mongoose');
+var User = require("../../models/user");
+var Post = require("../../models/post");
+
+module.exports = (on, config) => {
+  on('task', {
+    async 'resetDb'() {
+      
+      mongoose.connect('mongodb://127.0.0.1/acebook_test', {
+        useNewUrlParser: true,
+        useUnifiedTopology: true
+      });
+    
+      let db = mongoose.connection;
+
+      db.on('error', console.error.bind(console, 'MongoDB connection error:'));
+
+      //open is Emitted after 'connected' and 'onOpen' is executed on all of this connection's models.
+      // It means we can now work against these models on the database
+      // https://mongoosejs.com/docs/connections.html
+      db.on('open', function() {
+
+        User.deleteMany({}).then( () => {
+          console.log("User Test Data Deleted");
+        }).catch(function(error){
+          console.log(error); 
+        });
+
+        Post.deleteMany({}).then(function(){
+          console.log("Post Test Data Deleted");
+        }).catch(function(error){
+          console.log(error); 
+        });
+
+      });      
+      return null
+    },
+  })
+
+  on('task', {
+    async 'closeDbConnection'() {
+      mongoose.connection.close(() => {
+        console.log("Database Connection Closed");
+      });
+
+      return null
+    }
+    
+  })
 }

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -23,7 +23,7 @@ var Post = require("../../models/post");
 module.exports = (on, config) => {
   on('task', {
     async 'resetDb'() {
-      
+     
       mongoose.connect('mongodb://127.0.0.1/acebook_test', {
         useNewUrlParser: true,
         useUnifiedTopology: true

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -22,8 +22,12 @@
 // Alternatively you can use CommonJS syntax:
 require('./commands')
 
-// beforeEach(() => {
-//   // now this runs prior to every test
-//   // across all files no matter what
-//   cy.resetDb()
-// })
+beforeEach(() => {
+  // This runs prior to every test and clears all the data
+  cy.task('resetDb')
+})
+
+// ran at the end of all the specs
+after(() => {
+  cy.task('closeDbConnection')
+})

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -27,7 +27,7 @@ beforeEach(() => {
   cy.task('resetDb')
 })
 
-// ran at the end of all the specs
+// ran at the end of each specs
 after(() => {
   cy.task('closeDbConnection')
 })


### PR DESCRIPTION
Created 2 tasks for the Cypress plugin
```
resetDb
closeDbConnection
```
 to cypress/plugins/index.js

resetDb deletes all data in the User and Post collections. This is currently called before all tests that run in Cypress. This can be configured if we decide to change how we run our tests if needs be. 
closeDbConnection closes the mongoose connection. This task is called after all the tests have been completed

The plugin tasks are called from the cypress/support/index.js file